### PR TITLE
Make scheduler tick logs opt-in with `debug` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ COSMOS_RPC_URL=https://mainnet.infura.io/v3/YOUR_INFURA_KEY
 - **concurrency?**: Number of concurrent tasks to execute (default: `1`)
 - **autoExit?**: Automatically exit process when all periodic tasks complete (default: `false`)
 - **encryptionKey?**: Custom encryption key for task configs (default: uses `BLAZERJOB_ENCRYPTION_KEY` env var or a default key)
+- **debug?**: Enables internal scheduler logs (like `tick`) when set to `true` (default: `false`)
 
 ### schedule(taskFn: () => Promise<void>, opts: { ... }): number
 - **taskFn**: Asynchronous function to execute (your JS/TS code).

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export interface BlazeJobOptions {
   autoExit?: boolean;
   concurrency?: number;
   encryptionKey?: string;
+  debug?: boolean;
 }
 
 const ALGORITHM = 'aes-256-gcm';
@@ -70,6 +71,7 @@ export class BlazeJob {
   private onAllTasksEndedCb?: OnAllTasksEnded;
   private autoExit: boolean;
   private concurrency: number;
+  private debug: boolean;
   private activeTasksCount = 0;
   // Map: taskId -> taskFn (en mémoire)
   private taskFns = new Map<number, () => Promise<void>>();
@@ -88,6 +90,7 @@ export class BlazeJob {
     }
     this.autoExit = !!options.autoExit;
     this.concurrency = options.concurrency || 1;
+    this.debug = !!options.debug;
     this.db.prepare(`
       CREATE TABLE IF NOT EXISTS tasks (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -130,8 +133,10 @@ export class BlazeJob {
   }
 
   private async tick() {
-    console.log('[BlazeJob][DEBUG] tick() called. taskCount:', this.taskCount, 'taskRunStats:', Array.from(this.taskRunStats.keys()));
-    console.log('[BlazeJob] tick');
+    if (this.debug) {
+      console.log('[BlazeJob][DEBUG] tick() called. taskCount:', this.taskCount, 'taskRunStats:', Array.from(this.taskRunStats.keys()));
+      console.log('[BlazeJob] tick');
+    }
     type TaskRow = {
       id: number;
       runAt: string;


### PR DESCRIPTION
### Motivation
- Avoid noisy scheduler output by making the internal `tick()` logs optional so they are only printed when explicitly requested.

### Description
- Added a `debug?: boolean` field to `BlazeJobOptions`, stored as `this.debug` on the `BlazeJob` instance, and wrapped the `tick()` console logs to run only when `debug` is `true`; updated `README.md` to document the new option (`src/index.ts`, `README.md`).

### Testing
- Ran `npm run build` which invoked `tsc` and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4ab86b5048330b47af7acffc40084)